### PR TITLE
Add support for props.components as functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,25 @@ follows:
 
 ##### `components`
 
-The render prop components to compose.
+The render prop components to compose. This is an array of [React elements](https://reactjs.org/docs/glossary.html#elements) and/or functions that return elements given the currently accumulated results.
+
+```jsx
+<Composer
+  components={[
+    // Simple elements may be passed where previous results are not required.
+    <Outer />,
+    // A function may be passed that will be invoked with the currently accumulated results.
+    // Functions provided must return a valid React element.
+    ([outerResults]) => <Middle results={[outerResults]} />,
+    ([outerResults, middleResults]) => (
+      <Inner results={[outerResults, middleResults]} />
+    )
+  ]}>
+  {([outerResults, middleResults, innerResults]) => {
+    /* ... */
+  }}
+</Composer>
+```
 
 > Note: You do not need to specify the render prop on the components. If you do specify the render prop, it will
 > be ignored.

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,13 @@ export default function Composer({
     }
 
     const componentIndex = childrenComponents.length - 1;
-    const component = components[componentIndex];
+
+    const component =
+      // Each props.components entry is either an element or function [element factory]
+      // When it is a function, produce an element by invoking it with currently accumulated results.
+      typeof components[componentIndex] === 'function'
+        ? components[componentIndex](results)
+        : components[componentIndex];
 
     // This is the index of where we should place the response within `results`.
     // It's not the same as `componentIndex` because we reversed the components when
@@ -57,7 +63,9 @@ export default function Composer({
 
 Composer.propTypes = {
   children: PropTypes.func,
-  components: PropTypes.array,
+  components: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.element, PropTypes.func])
+  ),
   renderPropName: PropTypes.string,
   mapResult: PropTypes.func
 };


### PR DESCRIPTION
This enables passing either elements or functions in `props.components` to make use of the results of outer render prop components' results as input to inner render prop components for more flexible and advanced composition.

Related issue and discussion leading up to this: #19

- [x] Add support for `props.components` as functions
- [x] Add test
- [x] Update README with example

:memo: This is a non-breaking change.

The key of it was this hunk:

https://github.com/erikthedeveloper/react-composer/blob/da31bffa051746e1ef0c05ea5b9090248b34bc7f/src/index.js#L30-L35

```diff
-    const component = components[componentIndex];
+
+    const component =
+      // Each props.components entry is either an element or function [element factory]
+      // When it is a function, produce an element by invoking it with currently accumulated results.
+      typeof components[componentIndex] === 'function'
+        ? components[componentIndex](results)
+        : components[componentIndex];
```

Example usage:

```jsx
<Composer
  components={[
    // Simple elements may be passed where previous results are not required.
    <Outer />,
    // A function may be passed that will be invoked with the currently accumulated results.
    // Functions provided must return a valid React element.
    ([outerResults]) => <Middle results={[outerResults]} />,
    ([outerResults, middleResults]) => (
      <Inner results={[outerResults, middleResults]} />
    )
  ]}>
  {([outerResults, middleResults, innerResults]) => {
    /* ... */
  }}
</Composer>
```
