### PR TITLE
Shallow clone results before passing them down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### v3.1.1 (2018/2/8)
+
+**Bug Fixes**
+
+* This ensures that the argument passed to functions within the `components`
+  array is always a new array.
+
 ### v3.1.0 (2018/2/8)
 
 **New Features**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-composer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Compose render prop components",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export default function Composer({
       // Each props.components entry is either an element or function [element factory]
       // When it is a function, produce an element by invoking it with currently accumulated results.
       typeof components[componentIndex] === 'function'
-        ? components[componentIndex](results)
+        ? components[componentIndex]([...results])
         : components[componentIndex];
 
     // This is the index of where we should place the response within `results`.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -99,6 +99,7 @@ describe('React Composer', () => {
 
   describe('Render, three components; elements and functions', () => {
     test('It supports both elements and functions in props.components', () => {
+      let tempOuterResults;
       const wrapper = mount(
         <Composer
           components={[
@@ -107,12 +108,16 @@ describe('React Composer', () => {
 
             // A function [element factory] may be passed that is invoked with
             // the currently accumulated results to produce an element.
-            ([outerResult]) => {
+            (results) => {
+              tempOuterResults = results;
+              const [outerResult] = results;
               expect(outerResult).toEqual({ value: 'outer' });
               return <Echo value={`${outerResult.value} + middle`} />;
             },
 
-            ([outerResult, middleResult]) => {
+            (results) => {
+              expect(tempOuterResults).not.toBe(results);
+              const [outerResult, middleResult] = results;
               // Assert within element factory to avoid insane error messages for failed tests :)
               expect(outerResult).toEqual({ value: 'outer' });
               expect(middleResult).toEqual({ value: 'outer + middle' });


### PR DESCRIPTION
Whoops. Merged #29 too soon. The `results` need to be shallow cloned. :v:

//cc @erikthedeveloper 