### PR TITLE
Refactor chainComponents (bonus: reduce bundle size)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,54 +11,35 @@ export default function Composer({
     return null;
   }
 
-  // This is the argument that we pass into `children`.
-  const results = [];
-
-  // This is the list of components, reversed. We reverse them because the
-  // component that you list last will be the highest in the tree.
-  const reversedComponents = components.reverse();
-
-  function chainComponents(childrenComponents) {
+  /**
+   * Recursively build up elements from props.components and accumulate `results` along the way.
+   * @param next The first entry in components
+   * @param ...remaining The remaining entries in components
+   * @param results This is the argument that we pass into `children`
+   * @returns {ReactElement}
+   */
+  function chainComponents([next, ...remaining], results = []) {
     // When we reach the end of our `childrenComponents`, we can render out
     // the response array.
-    if (childrenComponents.length === 0) {
-      return children([...results]);
+    if (!next) {
+      return children(results);
     }
 
-    const componentIndex = childrenComponents.length - 1;
+    // Each props.components entry is either an element or function [element factory]
+    // When it is a function, produce an element by invoking it with currently accumulated results.
+    const element = typeof next === 'function' ? next(results) : next;
 
-    const component =
-      // Each props.components entry is either an element or function [element factory]
-      // When it is a function, produce an element by invoking it with currently accumulated results.
-      typeof components[componentIndex] === 'function'
-        ? components[componentIndex]([...results])
-        : components[componentIndex];
-
-    // This is the index of where we should place the response within `results`.
-    // It's not the same as `componentIndex` because we reversed the components when
-    // rendering out the components.
-    // In a sense, it can be thought of as the "reverse" index of `componentIndex`.
-    const responseIndex = reversedComponents.length - childrenComponents.length;
-
-    // We create a clone of the childrenComponents so that subsequent calls to `chidlren`
-    // render the same tree. If we modified `reversedComponents` directly, then the tree would
-    // be different with each call to `children`.
-    const childrenComponentsClone = [...childrenComponents];
-    childrenComponentsClone.pop();
-
-    return React.cloneElement(component, {
+    return React.cloneElement(element, {
       [renderPropName]() {
-        if (mapResult) {
-          results[responseIndex] = mapResult.apply(null, arguments);
-        } else {
-          results[responseIndex] = arguments[0];
-        }
-        return chainComponents(childrenComponentsClone);
+        return chainComponents(
+          remaining,
+          results.concat(mapResult ? [mapResult(...arguments)] : arguments[0])
+        );
       }
     });
   }
 
-  return chainComponents(reversedComponents);
+  return chainComponents(components);
 }
 
 Composer.propTypes = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -108,14 +108,14 @@ describe('React Composer', () => {
 
             // A function [element factory] may be passed that is invoked with
             // the currently accumulated results to produce an element.
-            (results) => {
+            results => {
               tempOuterResults = results;
               const [outerResult] = results;
               expect(outerResult).toEqual({ value: 'outer' });
               return <Echo value={`${outerResult.value} + middle`} />;
             },
 
-            (results) => {
+            results => {
               expect(tempOuterResults).not.toBe(results);
               const [outerResult, middleResult] = results;
               // Assert within element factory to avoid insane error messages for failed tests :)
@@ -179,7 +179,9 @@ describe('React Composer', () => {
       );
       expect(wrapper.contains(<div>spaghetti SPAGHETTI</div>)).toBe(true);
       expect(mockChildren).toHaveBeenCalledTimes(1);
-      expect(mockChildren.mock.calls[0]).toEqual([[['spaghetti', 'SPAGHETTI']]]);
+      expect(mockChildren.mock.calls[0]).toEqual([
+        [['spaghetti', 'SPAGHETTI']]
+      ]);
     });
   });
 });


### PR DESCRIPTION
Minor refactor of `chainComponents`. `results` is now recursively accumulated rather than dependent on scope.

Reduces bundle size by roughly 18% going from `524B` to `429B` as compared via `gzip-size dist/react-composer.min.js`

See discussion leading up this here: https://github.com/jmeas/react-composer/pull/33#issuecomment-364484063

![image](https://user-images.githubusercontent.com/1240178/36052925-f4114930-0dac-11e8-951d-796596594397.png)

:memo: Beyond the refactor, further bundle size reduction was thanks to using _less_ [not none] ES6/ES7 features that require Babel polyfilling. This reduced the bundle size by an additional ~14% with subjectively little cost to readability.

- Inline unnecessary interim variables
- Favor `defaultProps` over providing defaults in destructured arguments
- Remove `[next, ...remaining]` destructuring in favor of `components[0]` and `components.slice(1)`

Bonus: Add a few comments for clarity