### PR TITLE
Default mapResult to preserve multi-arg results

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,9 +36,7 @@ export default function Composer({
             // Remove the current component and continue.
             components.slice(1),
             // results.concat([mapped]) ensures [...results, mapped] instead of [...results, ...mapped]
-            results.concat(
-              mapResult ? [mapResult.apply(null, arguments)] : arguments[0]
-            )
+            results.concat([mapResult.apply(null, arguments)])
           );
         }
       }
@@ -54,10 +52,20 @@ Composer.propTypes = {
     PropTypes.oneOfType([PropTypes.element, PropTypes.func])
   ),
   renderPropName: PropTypes.string,
+  // mapResult is applied to the produced value(s) [arguments] of each render prop component.
   mapResult: PropTypes.func
 };
 
 Composer.defaultProps = {
   components: [],
-  renderPropName: 'children'
+  renderPropName: 'children',
+  // Most render prop components produce a single value for their render prop function.
+  // It is possible that a render prop function is invoked with multiple values.
+  //
+  // Default to provide produced results such as [someValue, [multiArgOne, multiArgTwo], anotherValue]
+  // When a single value is produced (this is typically the case): (producedObject) => producedObject
+  // When multiple values are produced: (producedOne, producedTwo) => [producedOne, producedTwo]
+  mapResult: function() {
+    return arguments.length === 1 ? arguments[0] : Array.from(arguments);
+  }
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -192,6 +192,37 @@ describe('React Composer', () => {
     });
   });
 
+  describe('props.mapResult', () => {
+    test('It defaults to preserve render prop signatures for multi-argument render prop functions', () => {
+      const wrapper = mount(
+        <Composer
+          components={[<Echo value="one" />, <DoubleEcho value="two" />]}
+          children={results => <MyComponent results={results} />}
+        />
+      );
+
+      expect(wrapper.find(MyComponent).prop('results')).toEqual([
+        { value: 'one' },
+        ['two', 'TWO']
+      ]);
+    });
+
+    test('It can be overridden for reasons of customization', () => {
+      const wrapper = mount(
+        <Composer
+          components={[<Echo value="one" />, <DoubleEcho value="two" />]}
+          mapResult={(...args) => ({ result: args })}
+          children={results => <MyComponent results={results} />}
+        />
+      );
+
+      expect(wrapper.find(MyComponent).prop('results')).toEqual([
+        { result: [{ value: 'one' }] },
+        { result: ['two', 'TWO'] }
+      ]);
+    });
+  });
+
   describe('Render, one component; custom `renderPropName`', () => {
     test('It should render the expected result', () => {
       const mockChildren = jest.fn(([result]) => <div>{result.value}</div>);
@@ -211,37 +242,6 @@ describe('React Composer', () => {
             value: 'spaghetti'
           }
         ]
-      ]);
-    });
-  });
-
-  describe('Render, one component; `mapResult`', () => {
-    test('It should render the expected result', () => {
-      const mockChildren = jest.fn(([result]) => (
-        <div>
-          {result[0]} {result[1]}
-        </div>
-      ));
-
-      const mapResult = jest.fn(function() {
-        return Array.from(arguments);
-      });
-
-      const wrapper = mount(
-        <Composer
-          components={[<DoubleEcho value="spaghetti" />]}
-          children={mockChildren}
-          mapResult={mapResult}
-        />
-      );
-
-      expect(mapResult).toHaveBeenCalledTimes(1);
-      expect(mapResult.mock.calls[0]).toEqual(['spaghetti', 'SPAGHETTI']);
-
-      expect(wrapper.contains(<div>spaghetti SPAGHETTI</div>)).toBe(true);
-      expect(mockChildren).toHaveBeenCalledTimes(1);
-      expect(mockChildren.mock.calls[0]).toEqual([
-        [['spaghetti', 'SPAGHETTI']]
       ]);
     });
   });


### PR DESCRIPTION
`props.mapResult` (optional) is applied to the produced value(s) [arguments] of each render prop component.

Most render prop components produce a single value/argument for their render prop function such as `children({a, b, c})`.

```js
function ProducesOneValue({children}) {
  return children({one: 'value', two: 'this is a single argument/value'});
}
```

It is possible that a render prop component may produce multiple values/arguments such as `children(a, b, c)`.

```js
function ProducesMultipleValues({children}) {
  return children('These', 'are', 'separate', 'arguments');
}
```

With this change:

When a single value is produced (this is typically the case), this would be equivalent of `props.mapResult = (producedObject) => producedObject`
When multiple values are produced, this would be equivalent of `props.mapResult = (producedOne, producedTwo) => [producedOne, producedTwo]`

In these seemingly rare cases, produced values would be preserved and results would be:

```js
[someValue, [multiArgOne, multiArgTwo], anotherValue]
```

compared with previous behavior resulting in:

```js
// Only keep first argument provided to each render prop function
[someValue, multiArgOne, anotherValue]
```
:memo: This is achieved and configurable via `defaultProps.mapResult`

https://github.com/jmeas/react-composer/blob/fec76745622988e40df44a9f287471da120045b9/src/index.js#L65-L70

⚠️ which is a breaking change for those depending on this default behavior of discarding multiple arguments beyond the first for multi-value producers. If `props.mapResult` is already overridden no breakage would occur.

---

:memo: This originally came up in discussion here: https://github.com/jmeas/react-composer/issues/37#issuecomment-364771045